### PR TITLE
 Exposed HM IP Port within the deployment script

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -86,7 +86,7 @@ if which dpkg>/dev/null && ! modinfo eq3_char_loop >/dev/null 2>&1 ; then
 fi
 
 #Calculate common options
-DOCKER_START_OPTS="--detach=true --name $DOCKER_NAME -p ${CCU_REGA_PORT}:80 -p ${CCU_RFD_PORT}:2001 -p ${CCU_SSH_PORT}:22 -p ${CCU_TCLREGASCRIPT_PORT}:8181 -e PERSISTENT_DIR=${DOCKER_VOLUME_INTERNAL_PATH} --hostname $DOCKER_NAME $DOCKER_OPTIONS ${DOCKER_REPO}:${DOCKER_TAG}"
+DOCKER_START_OPTS="--detach=true --name $DOCKER_NAME -p ${CCU_REGA_PORT}:80 -p ${CCU_RFD_PORT}:2001 -p ${CCU_IP_PORT}:2010 -p ${CCU_SSH_PORT}:22 -p ${CCU_TCLREGASCRIPT_PORT}:8181 -e PERSISTENT_DIR=${DOCKER_VOLUME_INTERNAL_PATH} --hostname $DOCKER_NAME $DOCKER_OPTIONS ${DOCKER_REPO}:${DOCKER_TAG}"
 DOCKER_START_OPTS="--mount type=bind,src=/sys,dst=/sys --mount type=bind,src=/dev,dst=/dev --mount type=volume,src=${DOCKER_CCU_DATA},dst=${DOCKER_VOLUME_INTERNAL_PATH} ${DOCKER_START_OPTS}"
 echo
 if [ $DOCKER_MODE = swarm ] ; then

--- a/settings.template
+++ b/settings.template
@@ -4,6 +4,9 @@
 #Rfd Port
 : ${CCU_RFD_PORT:=2001}
 
+#HM IP Port
+: ${CCU_IP_PORT:=2010}
+
 #TclRegaScript Port
 : ${CCU_TCLREGASCRIPT_PORT:=8181}
 


### PR DESCRIPTION
Hey there, 

thanks for the great work on your docker image. I've just successfully shipped the image, restored my local CCU3 (I've previously used piVCCU) backup and I'm able to communicate to my Homematic IP devices.

To be able to access the IP devices from another docker container (Home Assistant), I had to expose the port 2010. In case you want to integrate the configuration for this port within your deployment script, feel free to accept this PR. 

Again, thanks a lot for your work on this. You have saved me a a lot of time.


Best regards

